### PR TITLE
add oraclelinux to supported OSs

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -26,7 +26,7 @@ class sqlite::params {
     ubuntu, debian: {
       $package = 'sqlite3'
     }
-    centos, fedora, redhat: {
+    centos, fedora, redhat, oraclelinux: {
       $package = 'sqlite'
     }
     default: {


### PR DESCRIPTION
I think it will be better to use osfamily instead of operatingsystem